### PR TITLE
feat: rulebook bundle emitter + gateway stub + audit sidecar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ all: preflight lint type test audit
 # --- Norms & Bundles ---
 .PHONY: validate-norms emit-bundle
 
-validate-norms:
-	@python -c "import sys,re,pathlib; p=pathlib.Path('docs/norms/NormSet.base.yaml'); print(f'validating {p}…'); txt=p.read_text(encoding='utf-8'); assert re.search(r'^id:\\s+\\S+', txt, re.M), 'missing id in NormSet.base.yaml'; assert 'layers:' in txt, 'missing layers: in NormSet.base.yaml'; print('OK')"
+validate-norms: dev-install
+	$(VENV_DIR)/bin/python scripts/dev/validate_norms.py
 
 emit-bundle: dev-install
 	$(VENV_DIR)/bin/python scripts/urs_emit.py --format json --out docs/bundles/base.json

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,12 @@ audit: dev-install
 	$(VENV_DIR)/bin/python scripts/dev/norm_audit.py || true
 
 all: preflight lint type test audit
+
+# --- Norms & Bundles ---
+.PHONY: validate-norms emit-bundle
+
+validate-norms:
+	@python -c "import sys,re,pathlib; p=pathlib.Path('docs/norms/NormSet.base.yaml'); print(f'validating {p}…'); txt=p.read_text(encoding='utf-8'); assert re.search(r'^id:\\s+\\S+', txt, re.M), 'missing id in NormSet.base.yaml'; assert 'layers:' in txt, 'missing layers: in NormSet.base.yaml'; print('OK')"
+
+emit-bundle: dev-install
+	$(VENV_DIR)/bin/python scripts/urs_emit.py --format json --out docs/bundles/base.json

--- a/docs/norms/NormSet.schema.yaml
+++ b/docs/norms/NormSet.schema.yaml
@@ -1,0 +1,19 @@
+# Minimal schema sketch for NormSet files (human-readable, not enforced here)
+type: object
+required: [id, layers]
+properties:
+  id:
+    type: string
+  extends:
+    type: array
+    items: { type: string }
+  layers:
+    type: object
+    properties:
+      L0: { type: array }
+      L1: { type: array }
+      L2: { type: object }
+      L3: { type: object }
+    additionalProperties: true
+additionalProperties: true
+

--- a/docs/norms/NormSet.schema.yaml
+++ b/docs/norms/NormSet.schema.yaml
@@ -14,6 +14,4 @@ properties:
       L1: { type: array }
       L2: { type: object }
       L3: { type: object }
-    additionalProperties: true
 additionalProperties: true
-

--- a/examples/gateway_demo.md
+++ b/examples/gateway_demo.md
@@ -1,0 +1,11 @@
+# Gateway Demo
+
+```bash
+python - <<'PY'
+from gateway.apply_bundle import load_bundle, preflight, should_ask_stop
+b = load_bundle("docs/bundles/base.json")
+preflight(b)
+print("ask/stop?", should_ask_stop(b, "gh auth missing"))
+PY
+```
+

--- a/examples/gateway_demo.md
+++ b/examples/gateway_demo.md
@@ -4,8 +4,8 @@
 python - <<'PY'
 from gateway.apply_bundle import load_bundle, preflight, should_ask_stop
 b = load_bundle("docs/bundles/base.json")
-preflight(b)
+checked = preflight(b)
+print("checked tools:", checked)
 print("ask/stop?", should_ask_stop(b, "gh auth missing"))
 PY
 ```
-

--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -1,0 +1,5 @@
+# Re-export the module’s public API without duplicating symbols.
+from .apply_bundle import *  # noqa: F401,F403
+from .apply_bundle import __all__ as _apply_bundle_all  # noqa: F401
+
+__all__ = _apply_bundle_all

--- a/gateway/apply_bundle.py
+++ b/gateway/apply_bundle.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import pathlib
+import shutil
+import typing as t
+
+Bundle = t.Dict[str, t.Any]
+
+
+def load_bundle(path: str | pathlib.Path) -> Bundle:
+    p = pathlib.Path(path)
+    data = json.loads(p.read_text(encoding="utf-8"))
+    return t.cast(Bundle, data)
+
+
+def preflight(bundle: Bundle) -> None:
+    """Enforce pre-run checks derived from L2 gates.
+
+    Deterministic and side-effect-free: raises ValueError with actionable hints.
+    """
+    gates = bundle.get("layers", {}).get("L2", {}).get("gates", [])
+    missing: list[str] = []
+    root = pathlib.Path(__file__).resolve().parents[1]
+    venv_bin = root / ".venv" / "bin"
+    for tool in ("ruff", "mypy", "pytest"):
+        if tool in gates:
+            present = shutil.which(tool) is not None or (venv_bin / tool).exists()
+            if not present:
+                missing.append(tool)
+    if missing:
+        raise ValueError(f"Missing validators: {', '.join(missing)}. Install dev tools and retry.")
+
+
+def mask_io(bundle: Bundle, *, requires_db: bool = False) -> None:
+    # Placeholder: in real adapters, fence file/db usage based on policy.
+    if requires_db:
+        raise ValueError("DB access is not permitted in this context")
+
+
+def should_ask_stop(bundle: Bundle, event: str) -> str | None:
+    ask = bundle.get("ask_stop", {}).get("ask_if", [])
+    stop = bundle.get("ask_stop", {}).get("stop_if", [])
+    if any(k in event for k in stop):
+        return "STOP"
+    if any(k in event for k in ask):
+        return "ASK"
+    return None

--- a/gateway/apply_bundle.py
+++ b/gateway/apply_bundle.py
@@ -8,6 +8,18 @@ import typing as t
 
 Bundle = t.Dict[str, t.Any]
 
+ASK_SIGNAL = "ASK"
+STOP_SIGNAL = "STOP"
+CLI_GATES = {"ruff", "mypy", "pytest"}
+__all__ = [
+    "load_bundle",
+    "preflight",
+    "mask_io",
+    "should_ask_stop",
+    "ASK_SIGNAL",
+    "STOP_SIGNAL",
+]
+
 
 def load_bundle(path: str | pathlib.Path) -> Bundle:
     p = pathlib.Path(path)
@@ -15,22 +27,24 @@ def load_bundle(path: str | pathlib.Path) -> Bundle:
     return t.cast(Bundle, data)
 
 
-def preflight(bundle: Bundle) -> None:
-    """Enforce pre-run checks derived from L2 gates.
+def preflight(bundle: Bundle) -> list[str]:
+    """Check presence of CLI validators declared in the bundle (skip logical gates).
 
     Deterministic and side-effect-free: raises ValueError with actionable hints.
+    Returns the list of checked tools on success.
     """
-    gates = bundle.get("layers", {}).get("L2", {}).get("gates", [])
+    gates = list(bundle.get("layers", {}).get("L2", {}).get("gates", []))
+    cli = [g for g in gates if g in CLI_GATES]
     missing: list[str] = []
     root = pathlib.Path(__file__).resolve().parents[1]
     venv_bin = root / ".venv" / "bin"
-    for tool in ("ruff", "mypy", "pytest"):
-        if tool in gates:
-            present = shutil.which(tool) is not None or (venv_bin / tool).exists()
-            if not present:
-                missing.append(tool)
+    for tool in cli:
+        present = shutil.which(tool) is not None or (venv_bin / tool).exists()
+        if not present:
+            missing.append(tool)
     if missing:
         raise ValueError(f"Missing validators: {', '.join(missing)}. Install dev tools and retry.")
+    return cli
 
 
 def mask_io(bundle: Bundle, *, requires_db: bool = False) -> None:
@@ -43,7 +57,7 @@ def should_ask_stop(bundle: Bundle, event: str) -> str | None:
     ask = bundle.get("ask_stop", {}).get("ask_if", [])
     stop = bundle.get("ask_stop", {}).get("stop_if", [])
     if any(k in event for k in stop):
-        return "STOP"
+        return STOP_SIGNAL
     if any(k in event for k in ask):
-        return "ASK"
+        return ASK_SIGNAL
     return None

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 addopts = -q
 testpaths = tests
-
+pythonpath = .

--- a/scripts/dev/norm_audit.py
+++ b/scripts/dev/norm_audit.py
@@ -195,6 +195,15 @@ def main() -> int:
     ]
     md = "## Norm Audit\n" + "\n".join(summary_lines) + "\n\n```json\n" + json.dumps(payload, indent=2, sort_keys=True) + "\n```\n"
 
+    # Write JSON sidecar for dashboards (deterministic; narrow exceptions)
+    try:
+        side = REPORTS_DIR / f"PR-{args.pr}.json"
+        REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+        side.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    except (OSError, TypeError, ValueError):
+        # Non-fatal: journaling continues via markdown fallback
+        pass
+
     append_to_journal(args.pr, args.branch, md)
     return 0
 

--- a/scripts/dev/norm_audit.py
+++ b/scripts/dev/norm_audit.py
@@ -200,9 +200,9 @@ def main() -> int:
         side = REPORTS_DIR / f"PR-{args.pr}.json"
         REPORTS_DIR.mkdir(parents=True, exist_ok=True)
         side.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
-    except (OSError, TypeError, ValueError):
+    except (OSError, TypeError, ValueError) as e:
         # Non-fatal: journaling continues via markdown fallback
-        pass
+        print(f"Warning: failed to write audit JSON sidecar: {type(e).__name__}: {e}", file=sys.stderr)
 
     append_to_journal(args.pr, args.branch, md)
     return 0

--- a/scripts/dev/validate_norms.py
+++ b/scripts/dev/validate_norms.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Validate NormSet.base.yaml minimally (stdlib-only).
+
+Checks:
+- file exists and readable
+- has an `id:` at top-level
+- contains `layers:` block
+
+Exit codes:
+- 0: OK
+- 2: validation failure
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def validate(path: Path) -> list[str]:
+    errs: list[str] = []
+    try:
+        txt = path.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError) as e:
+        return [f"cannot read {path}: {type(e).__name__}: {e}"]
+
+    # Accept optional leading spaces and inline comments after the key
+    if not re.search(r"(?m)^\s*id\s*:\s*\S+", txt):
+        errs.append("missing `id:`")
+    if not re.search(r"(?m)^\s*layers\s*:\s*", txt):
+        errs.append("missing `layers:` block")
+    return errs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--path",
+        default="docs/norms/NormSet.base.yaml",
+        help="Path to NormSet YAML file",
+    )
+    args = ap.parse_args()
+    target = Path(args.path)
+    print(f"validating {target}…")
+    errs = validate(target)
+    if errs:
+        for e in errs:
+            print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(2)
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/urs_emit.py
+++ b/scripts/urs_emit.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Emit a portable Rulebook Bundle (JSON) combining L0–L3 + NormSet + gates.
+
+Constraints:
+- stdlib-only
+- Deterministic (no wall-clock); optional date via env var BUNDLE_DATE
+- Narrow exceptions; small surface
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPILED_RULEBOOK = ROOT / "docs" / "agents" / "Compiled.Rulebook.md"
+NORMSET_PATH = ROOT / "docs" / "norms" / "NormSet.base.yaml"
+
+
+def read_normset_id(path: Path) -> str:
+    try:
+        txt = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return "NormSet.base.v1"
+    m = re.search(r"^id:\s*([^\s#]+)", txt, flags=re.MULTILINE)
+    return m.group(1).strip() if m else "NormSet.base.v1"
+
+
+def parse_l0_l1_from_compiled_md(path: Path) -> Dict[str, List[str]]:
+    """Best-effort extraction of L0/L1 rule names from the compiled rulebook.
+    Falls back to documented constants if parsing is inconclusive.
+    """
+    try:
+        txt = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        txt = ""
+
+    l0: List[str] = []
+    l1: List[str] = []
+    cur = None
+    for line in txt.splitlines():
+        if re.match(r"^##+\s*L0\b", line):
+            cur = "L0"
+            continue
+        if re.match(r"^##+\s*L1\b", line):
+            cur = "L1"
+            continue
+        m = re.match(r"^\s*[-*]\s+([`\w][^`]+)\s*$", line)
+        if m and cur in {"L0", "L1"}:
+            name = m.group(1).strip().strip("` ")
+            (l0 if cur == "L0" else l1).append(name)
+
+    if not l0:
+        l0 = ["determinism.first", "small-diffs", "narrow-exceptions"]
+    if not l1:
+        l1 = ["exceptions.narrow", "io.guards"]
+    return {"L0": l0, "L1": l1}
+
+
+def build_bundle() -> Dict[str, Any]:
+    layers = parse_l0_l1_from_compiled_md(COMPILED_RULEBOOK)
+    # L2 gates per DoD (norm_audit validators)
+    l2 = {"gates": ["ruff", "mypy", "pytest", "docs_updated"]}
+    # L3 reporting (journals)
+    l3 = {"reporting": ["journals:activity", "journals:self"]}
+
+    generated_at = os.environ.get("BUNDLE_DATE", "1970-01-01")
+    normset_id = read_normset_id(NORMSET_PATH)
+
+    obj: Dict[str, Any] = {
+        "version": "rb-1",
+        "generated_at": generated_at,
+        "layers": {"L0": layers["L0"], "L1": layers["L1"], "L2": l2, "L3": l3},
+        "normset_id": normset_id,
+        "ask_stop": {
+            "ask_if": ["gh auth missing", "non-SSH origin", "validators absent"],
+            "stop_if": ["would violate L1", "non-stdlib dependency proposed"],
+        },
+        "waivers": [],
+    }
+    # Fingerprint over canonical JSON
+    canonical = json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    obj["fingerprint"] = "sha256:" + hashlib.sha256(canonical).hexdigest()
+    return obj
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--format", choices=["json"], default="json")
+    ap.add_argument("--out", required=True, help="output file path (json)")
+    args = ap.parse_args()
+
+    bundle = build_bundle()
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        out_path.write_text(json.dumps(bundle, indent=2, sort_keys=True), encoding="utf-8")
+    except (OSError, UnicodeEncodeError, TypeError) as e:
+        # Surface actionable message and non-zero exit deterministically
+        print(f"Error writing bundle to {out_path}: {type(e).__name__}: {e}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tests/test_gateway_basics.py
+++ b/tests/test_gateway_basics.py
@@ -1,0 +1,42 @@
+import pytest
+
+from gateway import ASK_SIGNAL, STOP_SIGNAL, preflight, should_ask_stop
+
+
+def test_should_ask_stop_returns_constant() -> None:
+    bundle = {
+        "ask_stop": {
+            "ask_if": ["gh auth missing"],
+            "stop_if": ["would violate L1"],
+        }
+    }
+    assert should_ask_stop(bundle, "gh auth missing") == ASK_SIGNAL
+    assert should_ask_stop(bundle, "would violate L1") == STOP_SIGNAL
+
+
+def test_preflight_checks_only_declared_gates() -> None:
+    # No gates: should not raise and returns empty list
+    assert preflight({"layers": {"L2": {"gates": []}}}) == []
+
+    # Non-CLI or logical gates should be ignored and not raise; returns empty list
+    assert preflight({"layers": {"L2": {"gates": ["__definitely_missing_tool__", "docs_updated"]}}}) == []
+
+
+def test_preflight_missing_cli_tool_raises(monkeypatch) -> None:
+    # Simulate missing CLI tools by patching detection to always fail
+    import gateway.apply_bundle as ab
+
+    monkeypatch.setattr(ab.shutil, "which", lambda name: None)
+
+    orig_exists = ab.pathlib.Path.exists
+
+    def fake_exists(self):  # type: ignore[no-redef]
+        # Mirror gateway.apply_bundle’s executable gates to avoid test drift
+        if self.name in ab.CLI_GATES and self.parent.name == "bin" and self.parent.parent.name == ".venv":
+            return False
+        return orig_exists(self)
+
+    monkeypatch.setattr(ab.pathlib.Path, "exists", fake_exists, raising=False)
+
+    with pytest.raises(ValueError):
+        preflight({"layers": {"L2": {"gates": ["ruff"]}}})


### PR DESCRIPTION
This PR adds a portable Rulebook Bundle emitter and a minimal gateway stub, plus audit JSON sidecar and Makefile helpers, all stdlib-only and deterministic.

What’s included
- scripts/urs_emit.py: emits docs/bundles/base.json (no wall-clock; BUNDLE_DATE env optional)
- gateway/apply_bundle.py: load/preflight/mask_io/should_ask_stop
- examples/gateway_demo.md: quick demo snippet
- scripts/dev/norm_audit.py: writes PR-<n>.json sidecar alongside markdown
- Makefile: validate-norms (light sanity), emit-bundle
- docs/norms/NormSet.schema.yaml: minimal schema sketch

Verification
- make dev-install
- make validate-norms
- make emit-bundle
- python - <<'PY'\nfrom gateway.apply_bundle import load_bundle, preflight, should_ask_stop\nb = load_bundle('docs/bundles/base.json'); preflight(b); print(should_ask_stop(b,'gh auth missing'))\nPY

Notes
- Kept L0–L3 norms: deterministic, narrow exceptions, small diffs.\n- Gateway preflight also accepts tools present in .venv/bin.
