### PR TITLE
chore: polish bundle+gateway PR (gates centralization, validator script, schema nit, stderr warn)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ all: preflight lint type test audit
 # --- Norms & Bundles ---
 .PHONY: validate-norms emit-bundle
 
-validate-norms:
-	@python -c "import sys,re,pathlib; p=pathlib.Path('docs/norms/NormSet.base.yaml'); print(f'validating {p}…'); txt=p.read_text(encoding='utf-8'); assert re.search(r'^id:\\s+\\S+', txt, re.M), 'missing id in NormSet.base.yaml'; assert 'layers:' in txt, 'missing layers: in NormSet.base.yaml'; print('OK')"
+validate-norms: dev-install
+	$(VENV_DIR)/bin/python scripts/dev/validate_norms.py
 
 emit-bundle: dev-install
 	$(VENV_DIR)/bin/python scripts/urs_emit.py --format json --out docs/bundles/base.json

--- a/docs/norms/NormSet.schema.yaml
+++ b/docs/norms/NormSet.schema.yaml
@@ -14,6 +14,4 @@ properties:
       L1: { type: array }
       L2: { type: object }
       L3: { type: object }
-    additionalProperties: true
 additionalProperties: true
-

--- a/examples/gateway_demo.md
+++ b/examples/gateway_demo.md
@@ -4,8 +4,8 @@
 python - <<'PY'
 from gateway.apply_bundle import load_bundle, preflight, should_ask_stop
 b = load_bundle("docs/bundles/base.json")
-preflight(b)
+checked = preflight(b)
+print("checked tools:", checked)
 print("ask/stop?", should_ask_stop(b, "gh auth missing"))
 PY
 ```
-

--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -1,17 +1,5 @@
-from .apply_bundle import (
-    ASK_SIGNAL,
-    STOP_SIGNAL,
-    load_bundle,
-    mask_io,
-    preflight,
-    should_ask_stop,
-)
+# Re-export the module’s public API without duplicating symbols.
+from .apply_bundle import *  # noqa: F401,F403
+from .apply_bundle import __all__ as _apply_bundle_all  # noqa: F401
 
-__all__ = [
-    "ASK_SIGNAL",
-    "STOP_SIGNAL",
-    "load_bundle",
-    "mask_io",
-    "preflight",
-    "should_ask_stop",
-]
+__all__ = _apply_bundle_all

--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -1,4 +1,17 @@
-__all__ = [
-    "apply_bundle",
-]
+from .apply_bundle import (
+    ASK_SIGNAL,
+    STOP_SIGNAL,
+    load_bundle,
+    mask_io,
+    preflight,
+    should_ask_stop,
+)
 
+__all__ = [
+    "ASK_SIGNAL",
+    "STOP_SIGNAL",
+    "load_bundle",
+    "mask_io",
+    "preflight",
+    "should_ask_stop",
+]

--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -1,0 +1,4 @@
+__all__ = [
+    "apply_bundle",
+]
+

--- a/gateway/apply_bundle.py
+++ b/gateway/apply_bundle.py
@@ -27,11 +27,11 @@ def load_bundle(path: str | pathlib.Path) -> Bundle:
     return t.cast(Bundle, data)
 
 
-def preflight(bundle: Bundle) -> dict[str, list[str]]:
+def preflight(bundle: Bundle) -> list[str]:
     """Check presence of CLI validators declared in the bundle (skip logical gates).
 
     Deterministic and side-effect-free: raises ValueError with actionable hints.
-    Returns a summary of checked gates.
+    Returns the list of checked tools on success.
     """
     gates = list(bundle.get("layers", {}).get("L2", {}).get("gates", []))
     cli = [g for g in gates if g in CLI_GATES]
@@ -43,8 +43,8 @@ def preflight(bundle: Bundle) -> dict[str, list[str]]:
         if not present:
             missing.append(tool)
     if missing:
-        raise ValueError(f"Missing validators: {', '.join(missing)}")
-    return {"checked": cli, "missing": []}
+        raise ValueError(f"Missing validators: {', '.join(missing)}. Install dev tools and retry.")
+    return cli
 
 
 def mask_io(bundle: Bundle, *, requires_db: bool = False) -> None:

--- a/gateway/apply_bundle.py
+++ b/gateway/apply_bundle.py
@@ -8,6 +8,17 @@ import typing as t
 
 Bundle = t.Dict[str, t.Any]
 
+ASK_SIGNAL = "ASK"
+STOP_SIGNAL = "STOP"
+__all__ = [
+    "load_bundle",
+    "preflight",
+    "mask_io",
+    "should_ask_stop",
+    "ASK_SIGNAL",
+    "STOP_SIGNAL",
+]
+
 
 def load_bundle(path: str | pathlib.Path) -> Bundle:
     p = pathlib.Path(path)
@@ -19,16 +30,16 @@ def preflight(bundle: Bundle) -> None:
     """Enforce pre-run checks derived from L2 gates.
 
     Deterministic and side-effect-free: raises ValueError with actionable hints.
+    Relies exclusively on gates declared in the bundle (no hardcoded tools).
     """
-    gates = bundle.get("layers", {}).get("L2", {}).get("gates", [])
+    gates = list(bundle.get("layers", {}).get("L2", {}).get("gates", []))
     missing: list[str] = []
     root = pathlib.Path(__file__).resolve().parents[1]
     venv_bin = root / ".venv" / "bin"
-    for tool in ("ruff", "mypy", "pytest"):
-        if tool in gates:
-            present = shutil.which(tool) is not None or (venv_bin / tool).exists()
-            if not present:
-                missing.append(tool)
+    for tool in gates:
+        present = shutil.which(tool) is not None or (venv_bin / tool).exists()
+        if not present:
+            missing.append(tool)
     if missing:
         raise ValueError(f"Missing validators: {', '.join(missing)}. Install dev tools and retry.")
 
@@ -43,7 +54,7 @@ def should_ask_stop(bundle: Bundle, event: str) -> str | None:
     ask = bundle.get("ask_stop", {}).get("ask_if", [])
     stop = bundle.get("ask_stop", {}).get("stop_if", [])
     if any(k in event for k in stop):
-        return "STOP"
+        return STOP_SIGNAL
     if any(k in event for k in ask):
-        return "ASK"
+        return ASK_SIGNAL
     return None

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 addopts = -q
 testpaths = tests
-
+pythonpath = .

--- a/scripts/dev/norm_audit.py
+++ b/scripts/dev/norm_audit.py
@@ -200,9 +200,9 @@ def main() -> int:
         side = REPORTS_DIR / f"PR-{args.pr}.json"
         REPORTS_DIR.mkdir(parents=True, exist_ok=True)
         side.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
-    except (OSError, TypeError, ValueError):
+    except (OSError, TypeError, ValueError) as e:
         # Non-fatal: journaling continues via markdown fallback
-        pass
+        print(f"Warning: failed to write audit JSON sidecar: {type(e).__name__}: {e}", file=sys.stderr)
 
     append_to_journal(args.pr, args.branch, md)
     return 0

--- a/scripts/dev/validate_norms.py
+++ b/scripts/dev/validate_norms.py
@@ -24,9 +24,10 @@ def validate(path: Path) -> list[str]:
     except (FileNotFoundError, OSError) as e:
         return [f"cannot read {path}: {type(e).__name__}: {e}"]
 
-    if not re.search(r"^id:\s+\S+", txt, re.M):
+    # Accept optional leading spaces and inline comments after the key
+    if not re.search(r"(?m)^\s*id\s*:\s*\S+", txt):
         errs.append("missing `id:`")
-    if not re.search(r"^layers:\s*$", txt, re.M):
+    if not re.search(r"(?m)^\s*layers\s*:\s*", txt):
         errs.append("missing `layers:` block")
     return errs
 

--- a/scripts/dev/validate_norms.py
+++ b/scripts/dev/validate_norms.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Validate NormSet.base.yaml minimally (stdlib-only).
+
+Checks:
+- file exists and readable
+- has an `id:` at top-level
+- contains `layers:` block
+
+Exit codes:
+- 0: OK
+- 2: validation failure
+"""
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+def validate(path: Path) -> list[str]:
+    errs: list[str] = []
+    try:
+        txt = path.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError) as e:
+        return [f"cannot read {path}: {type(e).__name__}: {e}"]
+
+    if not re.search(r"^id:\s+\S+", txt, re.M):
+        errs.append("missing top-level `id:`")
+    if "layers:" not in txt:
+        errs.append("missing `layers:` block")
+    return errs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--path",
+        default="docs/norms/NormSet.base.yaml",
+        help="Path to NormSet YAML file",
+    )
+    args = ap.parse_args()
+    target = Path(args.path)
+    print(f"validating {target}…")
+    errs = validate(target)
+    if errs:
+        for e in errs:
+            print(f"ERROR: {e}")
+        return 2
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/validate_norms.py
+++ b/scripts/dev/validate_norms.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import sys
 from pathlib import Path
 
 
@@ -45,8 +46,8 @@ def main() -> int:
     errs = validate(target)
     if errs:
         for e in errs:
-            print(f"ERROR: {e}")
-        return 2
+            print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(2)
     print("OK")
     return 0
 

--- a/scripts/dev/validate_norms.py
+++ b/scripts/dev/validate_norms.py
@@ -25,8 +25,8 @@ def validate(path: Path) -> list[str]:
         return [f"cannot read {path}: {type(e).__name__}: {e}"]
 
     if not re.search(r"^id:\s+\S+", txt, re.M):
-        errs.append("missing top-level `id:`")
-    if "layers:" not in txt:
+        errs.append("missing `id:`")
+    if not re.search(r"^layers:\s*$", txt, re.M):
         errs.append("missing `layers:` block")
     return errs
 

--- a/tests/test_gateway_basics.py
+++ b/tests/test_gateway_basics.py
@@ -31,7 +31,8 @@ def test_preflight_missing_cli_tool_raises(monkeypatch) -> None:
     orig_exists = ab.pathlib.Path.exists
 
     def fake_exists(self):  # type: ignore[no-redef]
-        if self.name in {"ruff", "mypy", "pytest"} and self.parent.name == "bin" and self.parent.parent.name == ".venv":
+        # Mirror gateway.apply_bundle’s executable gates to avoid test drift
+        if self.name in ab.CLI_GATES and self.parent.name == "bin" and self.parent.parent.name == ".venv":
             return False
         return orig_exists(self)
 

--- a/tests/test_gateway_basics.py
+++ b/tests/test_gateway_basics.py
@@ -1,0 +1,36 @@
+import pathlib
+import sys
+
+# Ensure project root is on sys.path for imports when running with testpaths
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from gateway.apply_bundle import (
+    ASK_SIGNAL,
+    STOP_SIGNAL,
+    preflight,
+    should_ask_stop,
+)
+
+
+def test_should_ask_stop_returns_constant() -> None:
+    bundle = {
+        "ask_stop": {
+            "ask_if": ["gh auth missing"],
+            "stop_if": ["would violate L1"],
+        }
+    }
+    assert should_ask_stop(bundle, "gh auth missing") == ASK_SIGNAL
+    assert should_ask_stop(bundle, "would violate L1") == STOP_SIGNAL
+
+
+def test_preflight_checks_only_declared_gates() -> None:
+    # No gates: should not raise
+    preflight({"layers": {"L2": {"gates": []}}})
+
+    # A clearly non-existent tool triggers a failure deterministically
+    try:
+        preflight({"layers": {"L2": {"gates": ["__definitely_missing_tool__"]}}})
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised is True

--- a/tests/test_gateway_basics.py
+++ b/tests/test_gateway_basics.py
@@ -1,9 +1,3 @@
-import pathlib
-import sys
-
-# Ensure project root is on sys.path for imports when running with testpaths
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
-
 from gateway import ASK_SIGNAL, STOP_SIGNAL, preflight, should_ask_stop
 
 

--- a/tests/test_gateway_basics.py
+++ b/tests/test_gateway_basics.py
@@ -4,12 +4,7 @@ import sys
 # Ensure project root is on sys.path for imports when running with testpaths
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
-from gateway.apply_bundle import (
-    ASK_SIGNAL,
-    STOP_SIGNAL,
-    preflight,
-    should_ask_stop,
-)
+from gateway import ASK_SIGNAL, STOP_SIGNAL, preflight, should_ask_stop
 
 
 def test_should_ask_stop_returns_constant() -> None:
@@ -25,12 +20,10 @@ def test_should_ask_stop_returns_constant() -> None:
 
 def test_preflight_checks_only_declared_gates() -> None:
     # No gates: should not raise
-    preflight({"layers": {"L2": {"gates": []}}})
+    assert preflight({"layers": {"L2": {"gates": []}}}) == {"checked": [], "missing": []}
 
-    # A clearly non-existent tool triggers a failure deterministically
-    try:
-        preflight({"layers": {"L2": {"gates": ["__definitely_missing_tool__"]}}})
-        raised = False
-    except ValueError:
-        raised = True
-    assert raised is True
+    # Non-CLI or logical gates should be ignored and not raise
+    assert preflight({"layers": {"L2": {"gates": ["__definitely_missing_tool__", "docs_updated"]}}}) == {
+        "checked": [],
+        "missing": [],
+    }


### PR DESCRIPTION
Polish pass for PR #4 to remove duplication and tighten scripts.

Changes
- refactor(gateway): use gates from bundle exclusively; add ASK/STOP constants and __all__
- chore(dev): add scripts/dev/validate_norms.py and wire Makefile target
- fix(schema): remove duplicate additionalProperties from NormSet schema
- chore(audit): log warning to stderr if JSON sidecar write fails (non-fatal)
- test(gateway): basic tests for ASK/STOP constants and preflight gate behavior

Verification
- make dev-install
- make validate-norms
- make lint && make type && make test

No behavioral changes to bundle content; stdlib-only; L0/L1/L2/L3 invariants intact.
