### PR TITLE
feat: auto-fix yaml.load to safe_load

### DIFF
--- a/docs/agents/enforcers.md
+++ b/docs/agents/enforcers.md
@@ -45,5 +45,6 @@ Lifecycle: scan → propose(auto) → agent(emit/ingest) → verify → commit |
   - Pipeline commands: `scan | propose | apply | verify`.
   - Idempotent transforms; deterministic outputs.
 - Add detectors/patchers for additional packs in later PRs.
+- YAML-015: replace yaml.load with yaml.safe_load (auto-fix; format-preserving; idempotent).
 - Wire CI enforcement and agent bridge.
 - Expand schema and verification hooks as needed.

--- a/tests/fixtures/packs/yaml_after.py
+++ b/tests/fixtures/packs/yaml_after.py
@@ -1,4 +1,8 @@
 # ruff: noqa: I001
 import yaml
+
 def loadit(s):
+    return yaml.safe_load(s)
+
+def load_with_loader(s):
     return yaml.safe_load(s)

--- a/tests/fixtures/packs/yaml_before.py
+++ b/tests/fixtures/packs/yaml_before.py
@@ -1,4 +1,8 @@
 # ruff: noqa: I001
 import yaml
+
 def loadit(s):
     return yaml.load(s)
+
+def load_with_loader(s):
+    return yaml.load(s, Loader=yaml.SafeLoader)

--- a/tests/hdae/test_patcher_ext.py
+++ b/tests/hdae/test_patcher_ext.py
@@ -1,0 +1,49 @@
+# ruff: noqa: I001
+from __future__ import annotations
+
+import difflib
+import os
+from pathlib import Path
+
+from tools.hdae.cli import main
+
+
+FIX = Path("tests/fixtures/packs")
+
+
+def test_yaml015_cli(tmp_path: Path, capsys) -> None:  # type: ignore[override]
+    before = (FIX / "yaml_before.py").read_text(encoding="utf-8")
+    after = (FIX / "yaml_after.py").read_text(encoding="utf-8")
+    test_file = tmp_path / "yaml_before.py"
+    test_file.write_text(before, encoding="utf-8")
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        main(["scan", "--packs", "YAML-015"])
+        scan_out = capsys.readouterr().out.strip().splitlines()
+        assert any("YAML-015" in line for line in scan_out)
+
+        main(["propose", "--dry-run", "--packs", "YAML-015"])
+        diff_out = capsys.readouterr().out
+        rel = f"./{test_file.name}"
+        expected = "".join(
+            difflib.unified_diff(
+                before.splitlines(True),
+                after.splitlines(True),
+                fromfile=f"a/{rel}",
+                tofile=f"b/{rel}",
+            )
+        )
+        assert diff_out == expected
+
+        main(["propose", "--apply", "--packs", "YAML-015"])
+        capsys.readouterr()
+        assert test_file.read_text(encoding="utf-8") == after
+
+        main(["propose", "--dry-run", "--packs", "YAML-015"])
+        idemp = capsys.readouterr().out
+        assert idemp == ""
+    finally:
+        os.chdir(cwd)
+

--- a/tools/hdae/cli.py
+++ b/tools/hdae/cli.py
@@ -300,7 +300,7 @@ def main(argv: List[str] | None = None) -> int:
                 s = _read(p)
             except OSError:
                 raise
-            new, diffs = apply_all(s, p)
+            new, diffs = apply_all(s, p, packs)
             if diffs:
                 for d in diffs:
                     if dry:


### PR DESCRIPTION
## Summary
- add libCST transformer for YAML-015 that rewrites `yaml.load` to `yaml.safe_load` and drops `Loader`
- wire CLI patcher to pack filter and new YAML fixer
- document YAML-015 pack and add regression tests

## Testing
- `pytest -q tests/hdae/test_patcher_ext.py -k yaml`
- `python -m tools.hdae.cli scan --packs YAML-015`
- `python -m tools.hdae.cli propose --dry-run --packs YAML-015`
- `python -m tools.hdae.cli propose --apply --packs YAML-015`
- `python -m tools.hdae.cli verify`
- `make ci-local PR_NUMBER=13 BASE_REF=track/hdae/pr12-agent-bridge` *(fails: PR_NUMBER?=0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0b411ff88320ae88d1a355b79b7d