### PR TITLE
Add auto-fix for ERR-011 linking original exceptions

### DIFF
--- a/docs/agents/enforcers.md
+++ b/docs/agents/enforcers.md
@@ -46,5 +46,6 @@ Lifecycle: scan → propose(auto) → agent(emit/ingest) → verify → commit |
   - Idempotent transforms; deterministic outputs.
 - Add detectors/patchers for additional packs in later PRs.
 - YAML-015: replace yaml.load with yaml.safe_load (auto-fix; format-preserving; idempotent).
+- ERR-011: link causal chain via `raise ... from e` (auto-fix; format-preserving; idempotent).
 - Wire CI enforcement and agent bridge.
 - Expand schema and verification hooks as needed.

--- a/tests/fixtures/packs/err_after.py
+++ b/tests/fixtures/packs/err_after.py
@@ -1,6 +1,39 @@
 # ruff: noqa: F821, F841
-def f():
+
+
+def case1():
     try:
         g()
     except ValueError as e:
-        raise RuntimeError('bad') from e
+        raise RuntimeError("bad") from e
+
+
+def case2():
+    try:
+        g()
+    except ValueError as e:
+        raise RuntimeError("bad") from e
+
+
+def case3():
+    try:
+        g()
+    except ValueError as e:
+        raise
+
+
+def case4():
+    try:
+        g()
+    except ValueError:
+        raise RuntimeError("bad")
+
+
+def case5():
+    try:
+        g()
+    except ValueError as e:
+        def inner():
+            raise RuntimeError("bad")
+        inner()
+

--- a/tests/fixtures/packs/err_before.py
+++ b/tests/fixtures/packs/err_before.py
@@ -1,6 +1,39 @@
 # ruff: noqa: F821, F841
-def f():
+
+
+def case1():
     try:
         g()
     except ValueError as e:
-        raise RuntimeError('bad')
+        raise RuntimeError("bad")
+
+
+def case2():
+    try:
+        g()
+    except ValueError as e:
+        raise RuntimeError("bad") from e
+
+
+def case3():
+    try:
+        g()
+    except ValueError as e:
+        raise
+
+
+def case4():
+    try:
+        g()
+    except ValueError:
+        raise RuntimeError("bad")
+
+
+def case5():
+    try:
+        g()
+    except ValueError as e:
+        def inner():
+            raise RuntimeError("bad")
+        inner()
+

--- a/tests/hdae/test_patcher_ext.py
+++ b/tests/hdae/test_patcher_ext.py
@@ -47,3 +47,40 @@ def test_yaml015_cli(tmp_path: Path, capsys) -> None:  # type: ignore[override]
     finally:
         os.chdir(cwd)
 
+
+def test_err011_cli(tmp_path: Path, capsys) -> None:  # type: ignore[override]
+    before = (FIX / "err_before.py").read_text(encoding="utf-8")
+    after = (FIX / "err_after.py").read_text(encoding="utf-8")
+    test_file = tmp_path / "err_before.py"
+    test_file.write_text(before, encoding="utf-8")
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        main(["scan", "--packs", "ERR-011"])
+        scan_out = capsys.readouterr().out.strip().splitlines()
+        assert any("ERR-011" in line for line in scan_out)
+
+        main(["propose", "--dry-run", "--packs", "ERR-011"])
+        diff_out = capsys.readouterr().out
+        rel = f"./{test_file.name}"
+        expected = "".join(
+            difflib.unified_diff(
+                before.splitlines(True),
+                after.splitlines(True),
+                fromfile=f"a/{rel}",
+                tofile=f"b/{rel}",
+            )
+        )
+        assert diff_out == expected
+
+        main(["propose", "--apply", "--packs", "ERR-011"])
+        capsys.readouterr()
+        assert test_file.read_text(encoding="utf-8") == after
+
+        main(["propose", "--dry-run", "--packs", "ERR-011"])
+        idemp = capsys.readouterr().out
+        assert idemp == ""
+    finally:
+        os.chdir(cwd)
+


### PR DESCRIPTION
## Summary
- add `Err011AddCause` CST transformer to append `from e` when raising a new exception inside an `except as e` block
- have CLI scan only flagged files for `ERR-011` and include cause in `_load_tf` error
- test and document ERR-011 auto-fix behavior

## Testing
- `pytest -q tests/hdae/test_patcher_ext.py -k err`
- `python -m tools.hdae.cli scan --packs ERR-011`
- `python -m tools.hdae.cli propose --dry-run --packs ERR-011`
- `python -m tools.hdae.cli propose --apply --packs ERR-011`
- `python -m tools.hdae.cli verify`
- `make ci-local PR_NUMBER=14 BASE_REF=track/hdae/pr13-yaml-safe-load` *(fails: `/bin/sh: 1: PR_NUMBER?=0: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68be0ffcbd408320818b862cde2e2c5b