### PR TITLE
Add pack registry and CLI lookup

### DIFF
--- a/docs/agents/enforcers.md
+++ b/docs/agents/enforcers.md
@@ -18,6 +18,15 @@ Descriptions:
 - Status: `status: {active|stub|disabled}` — only active TFs participate in scan/apply.
 - Four baseline TF packs are fully populated in this PR: BEX-001, SIL-002, MDA-003, SUB-006. Others are `status: stub` placeholders for later PRs.
 
+## Pack registry v0.1
+All packs are cataloged under `tools/hdae/packs.yaml` with their severity and
+auto-fix status. Discoverability and lookup are available via the CLI:
+
+```
+hdae packs --list            # tabular id/name/severity/auto
+hdae packs --explain <ID>    # show YAML entry for a pack
+```
+
 ## Waivers → Rulebook
 Waivers are defined in `Meta.yaml` under the `waivers:` list. The Rulebook compiler (`urs.py`) merges active waivers into the compiled output, and an index appears under each affected rule. For discoverability, waiver notes and rationale are mirrored at `docs/agents/waivers/`.
 

--- a/tests/hdae/test_packs_cli.py
+++ b/tests/hdae/test_packs_cli.py
@@ -1,0 +1,27 @@
+# ruff: noqa: I001
+# ruff: noqa: I001
+from __future__ import annotations
+
+from tools.hdae.cli import _load_packs, _render_pack_table, _render_pack_block, main
+
+
+def test_load_registry() -> None:
+    packs = _load_packs()
+    assert "BEX-001" in packs
+    assert packs["BEX-001"]["name"] == "Ban blanket except Exception"
+
+
+def test_cli_list(capsys) -> None:  # type: ignore[override]
+    main(["packs", "--list"])
+    out = capsys.readouterr().out
+    expected = _render_pack_table(_load_packs())
+    assert out == expected
+
+
+def test_cli_explain(capsys) -> None:  # type: ignore[override]
+    main(["packs", "--explain", "BEX-001"])
+    out = capsys.readouterr().out
+    packs = _load_packs()
+    expected = _render_pack_block("BEX-001", packs["BEX-001"])
+    assert out == expected
+

--- a/tools/hdae/packs.yaml
+++ b/tools/hdae/packs.yaml
@@ -1,0 +1,35 @@
+BEX-001:
+  name: Ban blanket except Exception
+  sev: high
+  auto: true
+  desc: Disallow bare or blanket except clauses.
+
+SIL-002:
+  name: Ban silent except
+  sev: high
+  auto: true
+  desc: Forbid except blocks that swallow errors.
+
+MDA-003:
+  name: Flag mutable default args
+  sev: high
+  auto: true
+  desc: Replace mutable default arguments.
+
+SUB-006:
+  name: Guard subprocess hazards
+  sev: medium
+  auto: false
+  desc: Detect risky subprocess usage.
+
+YAML-015:
+  name: Use yaml.safe_load
+  sev: medium
+  auto: true
+  desc: Replace yaml.load with safe_load.
+
+ERR-011:
+  name: Link causal chain via raise
+  sev: medium
+  auto: true
+  desc: Use raise ... from e to preserve context.


### PR DESCRIPTION
## Summary
- add packs.yaml registry with id, severity, auto-fix, and descriptions
- extend `hdae` CLI with `packs` command supporting `--list` and `--explain`
- document pack registry and cover functionality with unit tests

## Testing
- `python -m tools.hdae.cli packs --list`
- `python -m tools.hdae.cli packs --explain BEX-001`
- `make hdae-verify`

------
https://chatgpt.com/codex/tasks/task_e_68be946d90d48320a4923232170deb64