### PR TITLE
Add pre-commit hooks and document local CI parity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.12
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.17.1
+    hooks:
+      - id: mypy
+        args: [--ignore-missing-imports]
+        additional_dependencies: [types-PyYAML]
+  - repo: local
+    hooks:
+      - id: hdae-scan
+        name: hdae scan
+        entry: python -m tools.hdae.cli scan --packs YAML-015,ERR-011,LOG-010
+        language: system
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: venv dev-install preflight lint type test audit all
+.PHONY: venv dev-install preflight lint type test audit all hooks
 
 VENV_DIR := .venv
 DEV_SENTINEL := $(VENV_DIR)/.dev-deps-installed
@@ -31,6 +31,10 @@ audit: dev-install
 	$(VENV_DIR)/bin/python scripts/dev/norm_audit.py || true
 
 all: preflight lint type test audit
+
+.PHONY: hooks
+hooks:
+	pre-commit install
 
 # --- Norms & Bundles ---
 .PHONY: validate-norms emit-bundle

--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ Notes:
 - `make all` also runs an optional norm audit if present.
  - Imports are auto-sortable with `ruff` (run `ruff check --fix`).
 
+## Local parity
+
+Mirror CI checks before pushing a PR:
+
+```bash
+make ci-local PR_NUMBER=NN BASE_REF=main
+```
+
+Install pre-commit hooks:
+
+```bash
+make hooks
+```
+
 ## Agent Enforcers (H-DAE) ![H-DAE CI](https://github.com/LexLattice/lexlattice/actions/workflows/hdae.yml/badge.svg)
 
 This repo includes the skeleton for Hybrid Deterministic + Agent Enforcers:

--- a/scripts/dev/export_pr_feedback.py
+++ b/scripts/dev/export_pr_feedback.py
@@ -160,8 +160,8 @@ def main():
             print(f"Wrote {out_path}")
 
         if agg_f:
-            for e in entries:
-                row = {"repo": slug, "pr": pr, **e}
+            for entry in entries:
+                row = {"repo": slug, "pr": pr, **entry}
                 agg_f.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
 
     if agg_f:


### PR DESCRIPTION
## Summary
- add pre-commit configuration for ruff, mypy, and H-DAE scan
- provide `hooks` make target to install git hooks
- document local CI parity workflow

## Testing
- `pre-commit run --all-files`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68be946063508320982e05f376c23f46