### PR TITLE
feat: add async/secret detect-only packs

### DIFF
--- a/docs/agents/enforcers.md
+++ b/docs/agents/enforcers.md
@@ -49,3 +49,17 @@ Lifecycle: scan → propose(auto) → agent(emit/ingest) → verify → commit |
 - ERR-011: link causal chain via `raise ... from e` (auto-fix; format-preserving; idempotent).
 - Wire CI enforcement and agent bridge.
 - Expand schema and verification hooks as needed.
+
+## Detect-only async & secret packs (L2)
+- CON-019: `await` inside loops; suggest `asyncio.gather`.
+- CON-020: blocking I/O in `async def` (`requests.*`, `time.sleep`, `subprocess.run` with `check=False`, file I/O).
+- SEC-023: hardcoded secrets (AWS keys, long tokens, `api_key=...`, `Authorization: Bearer ...`).
+
+These emit L2 warnings by default and do not auto-fix. To waive:
+
+```yaml
+waivers:
+  - tf_id: CON-019
+  - tf_id: CON-020
+  - tf_id: SEC-023
+```

--- a/tests/fixtures/packs/con019_neg.py
+++ b/tests/fixtures/packs/con019_neg.py
@@ -1,0 +1,4 @@
+import asyncio
+
+async def good(urls):
+    await asyncio.gather(*(asyncio.sleep(1) for _ in urls))

--- a/tests/fixtures/packs/con019_pos.py
+++ b/tests/fixtures/packs/con019_pos.py
@@ -1,0 +1,5 @@
+import asyncio
+
+async def bad(urls):
+    for u in urls:
+        await asyncio.sleep(1)

--- a/tests/fixtures/packs/con020_neg.py
+++ b/tests/fixtures/packs/con020_neg.py
@@ -1,0 +1,4 @@
+import asyncio
+
+async def good():
+    await asyncio.sleep(1)

--- a/tests/fixtures/packs/con020_pos.py
+++ b/tests/fixtures/packs/con020_pos.py
@@ -1,0 +1,4 @@
+import requests
+
+async def bad():
+    requests.get('http://example.com')

--- a/tests/fixtures/packs/sec023_neg.py
+++ b/tests/fixtures/packs/sec023_neg.py
@@ -1,0 +1,2 @@
+def foo():
+    return 'nothing to see here'

--- a/tests/fixtures/packs/sec023_pos.py
+++ b/tests/fixtures/packs/sec023_pos.py
@@ -1,0 +1,4 @@
+AWS = "AKIA1234567890ABCDEF"
+TOKEN = "0123456789abcdef0123456789abcdef"
+URL = "https://example.com?api_key=0123456789abcdef0123456789abcdef"
+HDR = "Authorization: Bearer 0123456789abcdef0123456789abcdef"

--- a/tests/hdae/test_async_secret_packs.py
+++ b/tests/hdae/test_async_secret_packs.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.hdae.scan import scan_paths
+
+FIX = Path('tests/fixtures/packs')
+
+
+def _copy(tmp: Path, name: str) -> str:
+    p = tmp / name
+    p.write_text((FIX / name).read_text(encoding='utf-8'), encoding='utf-8')
+    return str(p)
+
+
+def test_con019(tmp_path: Path) -> None:
+    pos = _copy(tmp_path, 'con019_pos.py')
+    neg = _copy(tmp_path, 'con019_neg.py')
+    pf = scan_paths([pos])
+    nf = scan_paths([neg])
+    assert any(f.pack == 'CON-019' for f in pf)
+    assert not any(f.pack == 'CON-019' for f in nf)
+
+
+def test_con020(tmp_path: Path) -> None:
+    pos = _copy(tmp_path, 'con020_pos.py')
+    neg = _copy(tmp_path, 'con020_neg.py')
+    pf = scan_paths([pos])
+    nf = scan_paths([neg])
+    assert any(f.pack == 'CON-020' for f in pf)
+    assert not any(f.pack == 'CON-020' for f in nf)
+
+
+def test_sec023(tmp_path: Path) -> None:
+    pos = _copy(tmp_path, 'sec023_pos.py')
+    neg = _copy(tmp_path, 'sec023_neg.py')
+    pf = scan_paths([pos])
+    nf = scan_paths([neg])
+    assert any(f.pack == 'SEC-023' for f in pf)
+    assert not any(f.pack == 'SEC-023' for f in nf)
+


### PR DESCRIPTION
## Summary
- flag awaits inside loops (CON-019)
- warn on blocking I/O inside async functions (CON-020)
- detect hardcoded secrets like AWS keys and bearer tokens (SEC-023)
- document waivers for new detect-only packs

## Testing
- `pytest`
- `python -m tools.hdae.cli scan --packs CON-019,CON-020,SEC-023`

------
https://chatgpt.com/codex/tasks/task_e_68be947a28848320bdde0af2b2fcbfb9